### PR TITLE
Update README.md for chmod command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 - Run this command to give the setupEnvironment.sh script executable permissions: 
   
-  `chmod + x setupEnvironment.sh`
+  `chmod +x setupEnvironment.sh`
   
 - Run this command to create the required IAM roles and Lambda layer:
   


### PR DESCRIPTION
Modified "chmod + x" to "chmod +x", an additional space was causing the command to fail.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
